### PR TITLE
Impartire text pe limita de caractere

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,8 @@ impl EventHandler for Handler {
                                 }   
                                 message_chunk.clear();
                             }   
+                            message_chunk.push_str(verse);
+                            message_chunk.push('\n'); // Preserve line breaks between verses
                         }
                         if !message_chunk.is_empty() {
                             if let Err(why) = msg.channel_id.say(&ctx.http, &message_chunk).await {


### PR DESCRIPTION
Am adaugat o noua functionalitate, asigurandu-ma ca bucatile de text sa
nu depaseasca limita de 2k caractere. Cand se atinge aceasta limita,
versetul este trimis catre o noua bucata de text.

Closes #4